### PR TITLE
Due to clone mode infrastructure added by Pekka Paalanen weston_output

### DIFF
--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1405,7 +1405,7 @@ controller_create_screen(struct wl_client *client,
                         struct wl_resource *output_resource,
                         uint32_t id)
 {
-    struct weston_output *weston_output =
+    struct weston_head *weston_head =
         wl_resource_get_user_data(output_resource);
     struct wl_resource *screen_resource;
     struct ivicontroller *ctrl = wl_resource_get_user_data(resource);
@@ -1413,7 +1413,7 @@ controller_create_screen(struct wl_client *client,
 
 
     wl_list_for_each(iviscrn, &ctrl->shell->list_screen, link) {
-        if (weston_output != iviscrn->output) {
+        if (weston_head->output != iviscrn->output) {
             continue;
         }
 


### PR DESCRIPTION
is actually a entry to weston_head.

This fixes the situation where we get invalid protocol object when using
layer-add-surfaces.

Signed-off-by: Marius Vlad <marius-cristian.vlad@nxp.com>